### PR TITLE
QT refactor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,16 @@
     "eslint.validate": ["typescript"],
 	"typescript.tsdk": "node_modules\\typescript\\lib",
 	"typescript.preferences.quoteStyle": "single",
-	"cmake.configureOnOpen": false
+	"cmake.configureOnOpen": false,
+	"cSpell.words": [
+		"CISC",
+		"QTAGS",
+		"assignables",
+		"createc",
+		"createcourse",
+		"sreply",
+		"sudoreply",
+		"tagq",
+		"udel"
+	]
 }

--- a/config.example.ts
+++ b/config.example.ts
@@ -6,7 +6,14 @@ export const BOT = {
 
 export const PREFIX = 's;';
 
-export const MONGO = '';		// Mongo connection string here
+export const DB = {
+	CONNECTION: '', 			// Mongo connection string here
+	USERS: 'users',
+	PVQ: 'pvQuestions',
+	QTAGS: 'questionTags',
+	ASSIGNABLE: 'assignable',
+	COURSES: 'courses'
+};
 
 export const GUILDS = {			// Guild IDs for each guild
 	MAIN: '',

--- a/onboard/onboard.ts
+++ b/onboard/onboard.ts
@@ -4,7 +4,7 @@ import crypto from 'crypto';
 import nodemailer from 'nodemailer';
 import { MongoClient } from 'mongodb';
 import { SageUser } from '@lib/types/SageUser';
-import { BOT, EMAIL, GUILDS, MONGO } from '@root/config';
+import { BOT, DB, EMAIL, GUILDS } from '@root/config';
 
 const MESSAGE = `<!DOCTYPE html>
 <html>
@@ -38,8 +38,8 @@ const mailer = nodemailer.createTransport({
 });
 
 async function main() {
-	const client = await MongoClient.connect(MONGO, { useUnifiedTopology: true });
-	const db = client.db(BOT.NAME).collection('users');
+	const client = await MongoClient.connect(DB.CONNECTION, { useUnifiedTopology: true });
+	const db = client.db(BOT.NAME).collection(DB.USERS);
 	const data = fs.readFileSync('./resources/emails.csv');
 
 	const emails = data.toString().split('\n').map(email => email.trim());

--- a/src/commands/admin/setassign.ts
+++ b/src/commands/admin/setassign.ts
@@ -2,6 +2,7 @@ import { Message, Role } from 'discord.js';
 import { AssignableRole } from '@lib/types/AssignableRole';
 import { roleParser } from '@lib/arguments';
 import { adminPerms } from '@lib/permissions';
+import { DB } from '@root/config';
 
 export const description = `Adds a role to the assignable collection of the database 
 if that role is not already in it. If the role is already in the collection, it removes it.`;
@@ -14,7 +15,7 @@ export function permissions(msg: Message): boolean {
 }
 
 export async function run(msg: Message, [cmd]: [Role]): Promise<Message> {
-	const assignables = msg.client.mongo.collection('assignables');
+	const assignables = msg.client.mongo.collection(DB.ASSIGNABLE);
 	const newRole: AssignableRole = { id: cmd.id };
 
 	if (await assignables.countDocuments(newRole) > 0) {

--- a/src/commands/assign.ts
+++ b/src/commands/assign.ts
@@ -1,6 +1,7 @@
 import { Message, Role } from 'discord.js';
 import { AssignableRole } from '@lib/types/AssignableRole';
 import { roleParser } from '@lib/arguments';
+import { DB } from '@root/config';
 
 export const description = `Use this command to assign a role to yourself! 
 Use the argument 'list' to see a list of all self-assignable roles.`;
@@ -9,7 +10,7 @@ export const aliases = ['role'];
 export const runInDM = false;
 
 export async function run(msg: Message, [cmd]: [Role | 'list']): Promise<Message> {
-	const assignables = msg.client.mongo.collection('assignables');
+	const assignables = msg.client.mongo.collection(DB.ASSIGNABLE);
 	// const role: AssignableRole = { id: arg.id };
 
 	if (cmd === 'list') {

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,6 +1,6 @@
 import { Message } from 'discord.js';
 import { SageUser } from '@lib/types/SageUser';
-import { MAINTAINERS } from '@root/config';
+import { DB, MAINTAINERS } from '@root/config';
 
 export const description = `Displays the users current message count. 
 If the word 'here' is used as an argument, the message count will be 
@@ -9,7 +9,7 @@ export const usage = '[here]';
 export const aliases = ['count'];
 
 export async function run(msg: Message, [here]: [string]): Promise<void> {
-	const user: SageUser = await msg.author.client.mongo.collection('users').findOne({ discordId: msg.author.id });
+	const user: SageUser = await msg.author.client.mongo.collection(DB.USERS).findOne({ discordId: msg.author.id });
 
 	if (!user) {
 		msg.reply(`I couldn't find you in the database, if you think this is an error please contact ${MAINTAINERS}.`);

--- a/src/commands/configuration/addcourse.ts
+++ b/src/commands/configuration/addcourse.ts
@@ -3,7 +3,7 @@ import { Course } from '@lib/types/Course';
 import { adminPerms } from '@lib/permissions';
 import { DB, GUILDS, ROLES } from '@root/config';
 
-export const description = 'Creates a corses category and adds all necessary channels/roles.';
+export const description = 'Creates a courses category and adds all necessary channels/roles.';
 export const usage = '<course ID>';
 export const runInDM = false;
 export const aliases = ['addc', 'createcourse', 'createc'];

--- a/src/commands/configuration/addcourse.ts
+++ b/src/commands/configuration/addcourse.ts
@@ -1,9 +1,9 @@
 import { Message, OverwriteResolvable, Guild, TextChannel } from 'discord.js';
 import { Course } from '@lib/types/Course';
 import { adminPerms } from '@lib/permissions';
-import { GUILDS, ROLES } from '@root/config';
+import { DB, GUILDS, ROLES } from '@root/config';
 
-export const description = 'Creates a corses category and adds all nessary channels/roles.';
+export const description = 'Creates a corses category and adds all necessary channels/roles.';
 export const usage = '<course ID>';
 export const runInDM = false;
 export const aliases = ['addc', 'createcourse', 'createc'];
@@ -70,7 +70,7 @@ export async function run(msg: Message, [course]: [string]): Promise<Message> {
 		},
 		assignments: []
 	};
-	await msg.client.mongo.collection('courses').insertOne(newCourse);
+	await msg.client.mongo.collection(DB.COURSES).insertOne(newCourse);
 	return (await response).edit(`Added course with ID ${course}`);
 }
 
@@ -79,8 +79,8 @@ export async function argParser(msg: Message, input: string): Promise<Array<stri
 		throw `Usage: ${usage}`;
 	}
 
-	if (await msg.client.mongo.collection('courses').countDocuments({ name: input }) > 0) {
-		throw `${input} has already been regestered as a course.`;
+	if (await msg.client.mongo.collection(DB.COURSES).countDocuments({ name: input }) > 0) {
+		throw `${input} has already been registered as a course.`;
 	}
 
 	return [input];

--- a/src/commands/configuration/enroll.ts
+++ b/src/commands/configuration/enroll.ts
@@ -1,6 +1,7 @@
 import { Message } from 'discord.js';
 import { Course } from '@lib/types/Course';
 import { SageUser } from '@lib/types/SageUser';
+import { DB } from '@root/config';
 
 export const description = 'Enroll yourself in a course.';
 export const usage = '<course>';
@@ -8,14 +9,14 @@ export const extendedHelp = 'If you use this command on a course you are already
 export const runInDM = false;
 
 export async function run(msg: Message, [desiredCourse]: [string]): Promise<Message> {
-	const courses: Array<Course> = await msg.client.mongo.collection('courses').find().toArray();
+	const courses: Array<Course> = await msg.client.mongo.collection(DB.COURSES).find().toArray();
 	const course = courses.find(c => c.name === desiredCourse);
 
 	if (!course) {
-		return msg.channel.send(`Could not find course: ${desiredCourse}.\nAvaliable courses: \`${courses.map(c => c.name).join('`, `')}\``);
+		return msg.channel.send(`Could not find course: ${desiredCourse}.\nAvailable courses: \`${courses.map(c => c.name).join('`, `')}\``);
 	}
 
-	const user: SageUser = await msg.client.mongo.collection('users').findOne({ discordId: msg.member.id });
+	const user: SageUser = await msg.client.mongo.collection(DB.USERS).findOne({ discordId: msg.member.id });
 	const enroll = !user.courses.includes(course.name);
 
 	if (enroll) {
@@ -26,7 +27,7 @@ export async function run(msg: Message, [desiredCourse]: [string]): Promise<Mess
 		msg.member.roles.remove(course.roles.student, `Unenrolled from ${course.name}.`);
 	}
 
-	msg.client.mongo.collection('users').updateOne({ discordId: msg.member.id }, { $set: { ...user } });
+	msg.client.mongo.collection(DB.USERS).updateOne({ discordId: msg.member.id }, { $set: { ...user } });
 
 	return msg.channel.send(`You have been ${enroll ? 'enrolled in' : 'unenrolled from'} ${course.name}.`);
 }

--- a/src/commands/partial visibality question/anonymous.ts
+++ b/src/commands/partial visibality question/anonymous.ts
@@ -61,8 +61,8 @@ export async function argParser(msg: Message, input: string): Promise<[Course, s
 	} else {
 		const inputtedCourse = courses.find(c => c.name === input.split(' ')[0]);
 		if (!inputtedCourse) {
-			throw `I wasn't able to determine your course biased off of your enrollment or your input. Please specify the corse at the beginning of your question.
-Available corses: \`${courses.map(c => c.name).join('`, `')}\``;
+			throw 'I wasn\'t able to determine your course based off of your enrollment or your input. Please specify the course at the beginning of your question.' +
+			`\nAvailable courses: \`${courses.map(c => c.name).join('`, `')}\``;
 		}
 		course = inputtedCourse;
 		question = input.slice(course.name.length).trim();

--- a/src/commands/partial visibality question/anonymous.ts
+++ b/src/commands/partial visibality question/anonymous.ts
@@ -3,11 +3,11 @@ import { generateQuestionId } from '@lib/utils';
 import { Course } from '@lib/types/Course';
 import { SageUser } from '@lib/types/SageUser';
 import { PVQuestion } from '@lib/types/PVQuestion';
-import { BOT, MAINTAINERS, PREFIX } from '@root/config';
+import { BOT, DB, MAINTAINERS, PREFIX } from '@root/config';
 
 export const description = 'Send an anonymous question in your classes general channel.';
 export const usage = '[course] <question>';
-export const extendedHelp = `${BOT.NAME} will automaticly determine your course if you are only enrolled in one!`;
+export const extendedHelp = `${BOT.NAME} will automatically determine your course if you are only enrolled in one!`;
 export const aliases = ['anon'];
 export const runInGuild = false;
 
@@ -25,7 +25,7 @@ export async function run(msg: Message, [course, question]: [Course, string]): P
 	const staffEmbed = new MessageEmbed()
 		.setAuthor(`${msg.author.tag} (${msg.author.id}) asked Question ${questionId}`, msg.author.avatarURL())
 		.setDescription(`[Click to jump](${messageLink})
-It is recomended you reply in public, but sudoreply can be used **in a staff channel** to reply in private if nessary.`);
+It is recommended you reply in public, but sudoreply can be used **in a staff channel** to reply in private if necessary.`);
 
 	const staffChannel = await msg.client.channels.fetch(course.channels.staff) as TextChannel;
 	await staffChannel.send(staffEmbed);
@@ -37,19 +37,19 @@ It is recomended you reply in public, but sudoreply can be used **in a staff cha
 		messageLink
 	};
 
-	msg.client.mongo.collection('pvQuestions').insertOne(entry);
+	msg.client.mongo.collection(DB.PVQ).insertOne(entry);
 
 	return msg.channel.send(`Your question has been sent to your course anonymously. To reply anonymously, use \`${PREFIX}reply ${questionId} <response>\`.`);
 }
 
 export async function argParser(msg: Message, input: string): Promise<[Course, string]> {
-	const user: SageUser = await msg.client.mongo.collection('users').findOne({ discordId: msg.author.id });
+	const user: SageUser = await msg.client.mongo.collection(DB.USERS).findOne({ discordId: msg.author.id });
 
 	if (!user) throw `Something went wrong. Please contact ${MAINTAINERS}`;
 
 	let course: Course;
 	let question: string;
-	const courses: Array<Course> = await msg.client.mongo.collection('courses').find().toArray();
+	const courses: Array<Course> = await msg.client.mongo.collection(DB.COURSES).find().toArray();
 
 	if (user.courses.length === 1) {
 		course = courses.find(c => c.name === user.courses[0]);
@@ -61,8 +61,8 @@ export async function argParser(msg: Message, input: string): Promise<[Course, s
 	} else {
 		const inputtedCourse = courses.find(c => c.name === input.split(' ')[0]);
 		if (!inputtedCourse) {
-			throw `I wasn't able to determine your course baised off of your enrollment or your input. Please specify the corse at the begining of your question.
-Avaliable corses: \`${courses.map(c => c.name).join('`, `')}\``;
+			throw `I wasn't able to determine your course biased off of your enrollment or your input. Please specify the corse at the beginning of your question.
+Available corses: \`${courses.map(c => c.name).join('`, `')}\``;
 		}
 		course = inputtedCourse;
 		question = input.slice(course.name.length).trim();

--- a/src/commands/partial visibality question/private.ts
+++ b/src/commands/partial visibality question/private.ts
@@ -2,12 +2,12 @@ import { Message, MessageEmbed, TextChannel } from 'discord.js';
 import { Course } from '@lib/types/Course';
 import { PVQuestion } from '@lib/types/PVQuestion';
 import { SageUser } from '@lib/types/SageUser';
-import { BOT, MAINTAINERS, PREFIX } from '@root/config';
+import { BOT, DB, MAINTAINERS, PREFIX } from '@root/config';
 import { generateQuestionId } from '@lib/utils';
 
-export const description = 'Send a question to all course staff privatly.';
+export const description = 'Send a question to all course staff privately.';
 export const usage = '[course] <question>';
-export const extendedHelp = `${BOT.NAME} will automaticly determine your course if you are only enrolled in one!`;
+export const extendedHelp = `${BOT.NAME} will automatically determine your course if you are only enrolled in one!`;
 export const runInGuild = false;
 
 export async function run(msg: Message, [course, question]: [Course, string]): Promise<Message> {
@@ -16,7 +16,7 @@ export async function run(msg: Message, [course, question]: [Course, string]): P
 	const embed = new MessageEmbed()
 		.setAuthor(`${msg.author.tag} (${msg.author.id}) asked Question ${questionId}`, msg.author.avatarURL())
 		.setDescription(question)
-		.setFooter(`To respond to this question, use ${PREFIX}sudoreply ${questionId} <responce>`);
+		.setFooter(`To respond to this question, use ${PREFIX}sudoreply ${questionId} <response>`);
 
 	const staffChannel = await msg.client.channels.fetch(course.channels.staff) as TextChannel;
 	const questionMessage = await staffChannel.send(embed);
@@ -29,19 +29,19 @@ export async function run(msg: Message, [course, question]: [Course, string]): P
 		messageLink
 	};
 
-	msg.client.mongo.collection('pvQuestions').insertOne(entry);
+	msg.client.mongo.collection(DB.COURSES).insertOne(entry);
 
-	return msg.channel.send(`Your question has been sent to the staff, any responces will be sent here. Question ID: ${questionId}`);
+	return msg.channel.send(`Your question has been sent to the staff, any responses will be sent here. Question ID: ${questionId}`);
 }
 
 export async function argParser(msg: Message, input: string): Promise<[Course, string]> {
-	const user: SageUser = await msg.client.mongo.collection('users').findOne({ discordId: msg.author.id });
+	const user: SageUser = await msg.client.mongo.collection(DB.USERS).findOne({ discordId: msg.author.id });
 
 	if (!user) throw `Something went wrong. Please contact ${MAINTAINERS}`;
 
 	let course: Course;
 	let question: string;
-	const courses: Array<Course> = await msg.client.mongo.collection('courses').find().toArray();
+	const courses: Array<Course> = await msg.client.mongo.collection(DB.COURSES).find().toArray();
 
 	if (user.courses.length === 1) {
 		course = courses.find(c => c.name === user.courses[0]);
@@ -53,8 +53,8 @@ export async function argParser(msg: Message, input: string): Promise<[Course, s
 	} else {
 		const inputtedCourse = courses.find(c => c.name === input.split(' ')[0]);
 		if (!inputtedCourse) {
-			throw `I wasn't able to determine your course baised off of your enrollment or your input. Please specify the corse at the begining of your question.
-Avaliable corses: \`${courses.map(c => c.name).join('`, `')}\``;
+			throw `I wasn't able to determine your course biased off of your enrollment or your input. Please specify the corse at the beginning of your question.
+Available corses: \`${courses.map(c => c.name).join('`, `')}\``;
 		}
 		course = inputtedCourse;
 		question = input.slice(course.name.length).trim();

--- a/src/commands/partial visibality question/reply.ts
+++ b/src/commands/partial visibality question/reply.ts
@@ -1,9 +1,9 @@
 import { PVQuestion } from '@lib/types/PVQuestion';
-import { BOT } from '@root/config';
+import { BOT, DB } from '@root/config';
 import { MessageEmbed, Message, TextChannel } from 'discord.js';
 
 export const description = `Reply to a question you previously asked with ${BOT.NAME}.`;
-export const usage = '<questionID> <responce>';
+export const usage = '<questionID> <response>';
 export const runInGuild = false;
 
 export async function run(msg: Message, [question, response]: [PVQuestion, string]): Promise<Message> {
@@ -22,7 +22,7 @@ export async function run(msg: Message, [question, response]: [PVQuestion, strin
 }
 
 export async function argParser(msg: Message, input: string): Promise<[PVQuestion, string]> {
-	const question: PVQuestion = await msg.client.mongo.collection('pvQuestions').findOne({ questionId: input.split(' ')[0] });
+	const question: PVQuestion = await msg.client.mongo.collection(DB.PVQ).findOne({ questionId: input.split(' ')[0] });
 
 	if (!question) throw `Could not find question with an ID of **${input.split(' ')[0]}**.`;
 	if (question.owner !== msg.author.id) throw `You are not the owner of ${question.questionId}.`;

--- a/src/commands/partial visibality question/sudoreply.ts
+++ b/src/commands/partial visibality question/sudoreply.ts
@@ -1,10 +1,10 @@
 import { PVQuestion } from '@lib/types/PVQuestion';
-import { BOT, PREFIX } from '@root/config';
+import { BOT, DB, PREFIX } from '@root/config';
 import { staffPerms } from '@lib/permissions';
 import { Message, MessageEmbed } from 'discord.js';
 
 export const description = `Reply to a question asked through ${BOT.NAME}.`;
-export const usage = '<questionID> <responce>';
+export const usage = '<questionID> <response>';
 export const extendedHelp = 'Responses get sent to the askers DMs. This command will tell you it failed if it cannot send the DM.';
 export const runInDM = false;
 export const aliases = ['sreply'];
@@ -26,7 +26,7 @@ export async function run(msg: Message, [question, response]: [PVQuestion, strin
 }
 
 export async function argParser(msg: Message, input: string): Promise<[PVQuestion, string]> {
-	const question: PVQuestion = await msg.client.mongo.collection('pvQuestions').findOne({ questionId: input.split(' ')[0] });
+	const question: PVQuestion = await msg.client.mongo.collection(DB.PVQ).findOne({ questionId: input.split(' ')[0] });
 
 	if (!question) throw `Could not find question with an ID of **${input.split(' ')[0]}**.`;
 

--- a/src/commands/question tagging/addassignment.ts
+++ b/src/commands/question tagging/addassignment.ts
@@ -1,6 +1,7 @@
 import { EmbedField, Message, MessageEmbed } from 'discord.js';
 import { Course } from '@lib/types/Course';
 import { staffPerms } from '@lib/permissions';
+import { DB } from '@root/config';
 
 // Never assume staff are not dumb (the reason this is so long)
 
@@ -14,7 +15,7 @@ export function permissions(msg: Message): boolean {
 }
 
 export async function run(msg: Message, [course, newAssignments]: [string, Array<string>]): Promise<Message> {
-	const entry: Course = await msg.client.mongo.collection('courses').findOne({ name: course });
+	const entry: Course = await msg.client.mongo.collection(DB.COURSES).findOne({ name: course });
 
 	const added: Array<string> = [];
 	const failed: Array<string> = [];
@@ -27,7 +28,7 @@ export async function run(msg: Message, [course, newAssignments]: [string, Array
 		}
 	});
 
-	msg.client.mongo.collection('courses').updateOne({ name: course }, { $set: { ...entry } });
+	msg.client.mongo.collection(DB.COURSES).updateOne({ name: course }, { $set: { ...entry } });
 
 	const fields: Array<EmbedField> = [];
 	if (added.length > 0) {
@@ -60,7 +61,7 @@ export async function argParser(msg: Message, input: string): Promise<[string, A
 	const assignments = input.split('|').map(assignment => assignment.trim());
 	const course = assignments.shift();
 
-	if (await msg.client.mongo.collection('courses').countDocuments({ name: course }) !== 1) {
+	if (await msg.client.mongo.collection(DB.COURSES).countDocuments({ name: course }) !== 1) {
 		throw `Could not find course: ${course}`;
 	}
 

--- a/src/commands/question tagging/question.ts
+++ b/src/commands/question tagging/question.ts
@@ -67,7 +67,7 @@ export async function argParser(msg: Message, input: string): Promise<[string, s
 	} else {
 		const inputtedCourse = courses.find(c => c.name === input.split(' ')[0]);
 		if (!inputtedCourse) {
-			throw 'I wasn\'t able to determine your course biased off of your enrollment or your input. Please specify the corse at the beginning of your question.' +
+			throw 'I wasn\'t able to determine your course based off of your enrollment or your input. Please specify the course at the beginning of your question.' +
 			`\nAvailable corses: \`${courses.map(c => c.name).join('`, `')}\``;
 		}
 		course = inputtedCourse;

--- a/src/commands/question tagging/question.ts
+++ b/src/commands/question tagging/question.ts
@@ -1,7 +1,7 @@
 import { EmbedField, Message, MessageEmbed } from 'discord.js';
 import { Course } from '@lib/types/Course';
-import { PREFIX } from '@root/config';
-import { Question } from '@lib/types/Question';
+import { DB, PREFIX } from '@root/config';
+import { QuestionTag } from '@root/src/lib/types/QuestionTag';
 
 export const description = 'Filters the questionTags collection for a given class and assignment';
 export const usage = '<courseID>|<assignmentID>';
@@ -10,7 +10,7 @@ export const aliases = ['q'];
 // never assume that students are not dumb
 
 export async function run(msg: Message, [course, assignment]: [string, string]): Promise<Message> {
-	const entries: Array<Question> = await msg.client.mongo.collection('questions').find({ course: course, assignment: assignment }).toArray();
+	const entries: Array<QuestionTag> = await msg.client.mongo.collection(DB.QTAGS).find({ course: course, assignment: assignment }).toArray();
 	const fields: Array<EmbedField> = [];
 	if (entries.length === 0) {
 		return msg.channel.send(`There are no questions for ${course}, ${assignment}.
@@ -33,13 +33,13 @@ export async function argParser(msg: Message, input: string): Promise<[string, s
 		throw `Usage: ${usage}`;
 	}
 
-	const entry: Course = await msg.client.mongo.collection('courses').findOne({ name: course });
+	const entry: Course = await msg.client.mongo.collection(DB.COURSES).findOne({ name: course });
 	if (!entry) {
 		throw `Could not find course: **${course}**`;
 	}
 
 	if (!entry.assignments.includes(assignment)) {
-		throw `Could not find assignment **${assignment}** in course: **${course}**.\n${course} curently has these assignments:\n\`${entry.assignments.join('`, `')}\``;
+		throw `Could not find assignment **${assignment}** in course: **${course}**.\n${course} currently has these assignments:\n\`${entry.assignments.join('`, `')}\``;
 	}
 
 	return [course, assignment];

--- a/src/commands/staff/lookup.ts
+++ b/src/commands/staff/lookup.ts
@@ -1,4 +1,4 @@
-import { EMAIL, MAINTAINERS } from '@root/config';
+import { DB, EMAIL, MAINTAINERS } from '@root/config';
 import { userParser } from '@lib/arguments';
 import { staffPerms } from '@lib/permissions';
 import { SageUser } from '@lib/types/SageUser';
@@ -14,7 +14,7 @@ export function permissions(msg: Message): boolean {
 }
 
 export async function run(msg: Message, member: GuildMember): Promise<void> {
-	const entry: SageUser = await msg.client.mongo.collection('users').findOne({ discordId: member.user.id });
+	const entry: SageUser = await msg.client.mongo.collection(DB.USERS).findOne({ discordId: member.user.id });
 
 	if (!entry) {
 		throw `User ${member.user.username} (${member.user.id}) not in database. Contact ${MAINTAINERS} 
@@ -39,7 +39,7 @@ export async function run(msg: Message, member: GuildMember): Promise<void> {
 		]);
 
 	if (!entry.pii) {
-		const sender: SageUser = await msg.client.mongo.collection('users').findOne({ discordId: msg.author.id });
+		const sender: SageUser = await msg.client.mongo.collection(DB.USERS).findOne({ discordId: msg.author.id });
 		msg.channel.send(`That user has not opted in to have their information shared over Discord. 
 An email has been sent to you containing the requested data.`);
 		sendEmail(sender.email, member.user.username, entry);
@@ -47,7 +47,7 @@ An email has been sent to you containing the requested data.`);
 	}
 
 	msg.author.send(embed).then(() => msg.channel.send('I\'ve sent the requested info to your DMs'))
-		.catch(() => msg.channel.send('I couldnt send you a DM. Please enable DMs and try again'));
+		.catch(() => msg.channel.send('I couldn\'t send you a DM. Please enable DMs and try again'));
 	return;
 }
 

--- a/src/commands/staff/resetlevel.ts
+++ b/src/commands/staff/resetlevel.ts
@@ -2,7 +2,7 @@ import { staffPerms } from '@lib/permissions';
 import { userParser } from '@lib/arguments';
 import { SageUser } from '@lib/types/SageUser';
 import { GuildMember, Message } from 'discord.js';
-import { MAINTAINERS } from '@root/config';
+import { DB, MAINTAINERS } from '@root/config';
 
 export const description = 'Resets a given user\'s message count.';
 export const usage = '<user>|[to_subtract|to_set_to]';
@@ -16,7 +16,7 @@ export function permissions(msg: Message): boolean {
 }
 
 export async function run(msg: Message, [member, amount]: [GuildMember, number]): Promise<Message> {
-	const entry: SageUser = await msg.client.mongo.collection('users').findOne({ discordId: member.user.id });
+	const entry: SageUser = await msg.client.mongo.collection(DB.USERS).findOne({ discordId: member.user.id });
 
 	if (!entry) {
 		throw `User ${member.user.username} (${member.user.id}) not in database. Contact ${MAINTAINERS} 
@@ -38,7 +38,7 @@ export async function run(msg: Message, [member, amount]: [GuildMember, number])
 		retStr = `Set ${member.user.username}'s message count to ${amount}.`;
 	}
 
-	await msg.client.mongo.collection('users').updateOne(
+	await msg.client.mongo.collection(DB.USERS).updateOne(
 		{ discordId: member.user.id },
 		{ $set: { count: entry.count } });
 

--- a/src/lib/types/QuestionTag.d.ts
+++ b/src/lib/types/QuestionTag.d.ts
@@ -1,4 +1,4 @@
-export interface Question {
+export interface QuestionTag {
 	link: string;
 	course: string;
 	assignment: string;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { Client, Message } from 'discord.js';
 import fetch from 'node-fetch';
 import { Command } from '@lib/types/Command';
+import { DB } from '@root/config';
 
 export function getCommand(bot: Client, cmd: string): Command {
 	cmd = cmd.toLowerCase();
@@ -17,7 +18,7 @@ export async function sendToHastebin(input: string, filetype = 'txt'): Promise<s
 export async function generateQuestionId(msg: Message, depth = 1): Promise<string> {
 	const potentialId = `${msg.author.id.slice(msg.author.id.length - depth)}${msg.id.slice(msg.id.length - depth)}`;
 
-	if (await msg.client.mongo.collection('pvQuestions').countDocuments({ questionId: potentialId }) > 0) {
+	if (await msg.client.mongo.collection(DB.PVQ).countDocuments({ questionId: potentialId }) > 0) {
 		return generateQuestionId(msg, depth + 1);
 	}
 

--- a/src/pieces/messageCount.ts
+++ b/src/pieces/messageCount.ts
@@ -1,5 +1,5 @@
 import { Client, TextChannel } from 'discord.js';
-import { PREFIX } from '@root/config';
+import { DB, PREFIX } from '@root/config';
 
 function register(bot: Client): void {
 	bot.on('message', msg => {
@@ -12,7 +12,7 @@ function register(bot: Client): void {
 			return;
 		}
 
-		bot.mongo.collection('users').updateOne(
+		bot.mongo.collection(DB.USERS).updateOne(
 			{ discordId: msg.author.id },
 			{ $inc: { count: 1 } })
 			.then(updated => {

--- a/src/pieces/roleHandler.ts
+++ b/src/pieces/roleHandler.ts
@@ -1,11 +1,11 @@
 import { Client, GuildMember } from 'discord.js';
-import { GUILDS } from '@root/config';
+import { DB, GUILDS } from '@root/config';
 import { SageUser } from '@lib/types/SageUser';
 
 async function memberAdd(member: GuildMember): Promise<void> {
 	if (member.guild.id !== GUILDS.MAIN) return;
 
-	const entry: SageUser = await member.client.mongo.collection('users').findOne({ discordId: member.id });
+	const entry: SageUser = await member.client.mongo.collection(DB.USERS).findOne({ discordId: member.id });
 
 	if (!entry) {
 		throw `User ${member.id} does not exist in the database.`;
@@ -22,7 +22,7 @@ async function memberAdd(member: GuildMember): Promise<void> {
 async function memberUpdate(oldMember: GuildMember, newMember: GuildMember): Promise<void> {
 	if (newMember.roles.cache.size === oldMember.roles.cache.size) return;
 
-	newMember.client.mongo.collection('users').updateOne({ discordId: newMember.id }, {
+	newMember.client.mongo.collection(DB.USERS).updateOne({ discordId: newMember.id }, {
 		$set: {
 			roles: newMember.roles.cache.keyArray().filter(role => role !== GUILDS.MAIN)
 		}

--- a/src/pieces/verification.ts
+++ b/src/pieces/verification.ts
@@ -1,6 +1,6 @@
 import { Client } from 'discord.js';
 import { SageUser } from '@lib/types/SageUser';
-import { GUILDS, MAINTAINERS, ROLES } from '@root/config';
+import { DB, GUILDS, MAINTAINERS, ROLES } from '@root/config';
 
 async function register(bot: Client): Promise<void> {
 	const guild = await bot.guilds.fetch(GUILDS.MAIN);
@@ -11,11 +11,11 @@ async function register(bot: Client): Promise<void> {
 
 		const givenHash = msg.content.trim();
 
-		if (await bot.mongo.collection('users').countDocuments({ discordId: msg.author.id }) > 0) {
+		if (await bot.mongo.collection(DB.USERS).countDocuments({ discordId: msg.author.id }) > 0) {
 			return msg.reply(`Your Discord account has already been verified. Contact ${MAINTAINERS} if you think this is an error.`);
 		}
 
-		const entry: SageUser = await bot.mongo.collection('users').findOne({ hash: givenHash });
+		const entry: SageUser = await bot.mongo.collection(DB.USERS).findOne({ hash: givenHash });
 
 		if (!entry) {
 			return msg.reply(`I could not find that hash in the database. Please try again or contact ${MAINTAINERS}.`);
@@ -38,7 +38,7 @@ async function register(bot: Client): Promise<void> {
 			}
 		}
 
-		bot.mongo.collection('users').updateOne(
+		bot.mongo.collection(DB.USERS).updateOne(
 			{ hash: givenHash },
 			{ $set: { ...entry } })
 			.then(async () => {

--- a/src/sage.ts
+++ b/src/sage.ts
@@ -1,5 +1,5 @@
 import 'module-alias/register';
-import { BOT, MONGO, PREFIX } from '@root/config';
+import { BOT, DB, PREFIX } from '@root/config';
 import commandManager from '@pieces/commandManager';
 import roleHandler from '@pieces/roleHandler';
 import messageCount from '@pieces/messageCount';
@@ -9,7 +9,7 @@ import { Client } from 'discord.js';
 
 const bot = new Client();
 
-MongoClient.connect(MONGO, { useUnifiedTopology: true }).then((client) => {
+MongoClient.connect(DB.CONNECTION, { useUnifiedTopology: true }).then((client) => {
 	bot.mongo = client.db(BOT.NAME);
 });
 


### PR DESCRIPTION
Closes #44. The `question` and `tagquestion` commands now take args in a much friendlier way utilizing course info from the context of the message. Also, collection names were moved to the config because I had to change one and it was a pain so I thought I would make it easier to change if necessary in the future.