### PR TITLE
fixes to commands/dropdown

### DIFF
--- a/src/commands/admin/announce.ts
+++ b/src/commands/admin/announce.ts
@@ -34,7 +34,7 @@ export default class extends Command {
 		let content = interaction.options.getString('content');
 
 		const tempMessage = content.split(`\\n`);
-		content = tempMessage.join(`\n\n`);
+		content = tempMessage.join(`\n`);
 
 		const channel = (channelOption || announceChannel) as TextChannel;
 		await channel.send({

--- a/src/commands/admin/announce.ts
+++ b/src/commands/admin/announce.ts
@@ -16,7 +16,7 @@ export default class extends Command {
 	},
 	{
 		name: 'content',
-		description: 'The announcement content',
+		description: `The announcement content. Adding in \n will add in a line break.`,
 		type: 'STRING',
 		required: true
 	},
@@ -30,8 +30,11 @@ export default class extends Command {
 	async run(interaction: CommandInteraction): Promise<void> {
 		const announceChannel = interaction.guild.channels.cache.get(CHANNELS.ANNOUNCEMENTS);
 		const channelOption = interaction.options.getChannel('channel');
-		const content = interaction.options.getString('content');
 		const image = interaction.options.getString('image');
+		let content = interaction.options.getString('content');
+
+		const tempMessage = content.split(`\\n`);
+		content = tempMessage.join(`\n\n`);
 
 		const channel = (channelOption || announceChannel) as TextChannel;
 		await channel.send({

--- a/src/commands/admin/edit.ts
+++ b/src/commands/admin/edit.ts
@@ -17,14 +17,14 @@ export default class extends Command {
 	},
 	{
 		name: 'msg_content',
-		description: 'The updated message content.',
+		description: 'The updated message content. Adding in \n will add in a line break.',
 		type: 'STRING',
 		required: true
 	}]
 
 	async run(interaction: CommandInteraction): Promise<void> {
 		const link = interaction.options.getString('msg_link');
-		const content = interaction.options.getString('msg_content');
+		let content = interaction.options.getString('msg_content');
 
 		//	for discord canary users, links are different
 		const newLink = link.replace('canary.', '');
@@ -43,6 +43,10 @@ export default class extends Command {
 				{ content: `It seems I can't edit that message. You'll need to tag a message that was sent by me, ${BOT.NAME}`,
 					ephemeral: true });
 		}
+
+		const tempMessage = content.split(`\\n`);
+		content = tempMessage.join(`\n`);
+
 		await message.edit(content);
 		return interaction.reply('I\'ve updated that message.');
 	}

--- a/src/commands/admin/removecourse.ts
+++ b/src/commands/admin/removecourse.ts
@@ -49,16 +49,15 @@ export default class extends Command {
 		interaction.fetchReply().then(reply => { replyId = reply.id; });
 
 		const collector = interaction.channel.createMessageComponentCollector({
-			max: 1,
 			time: DECISION_TIMEOUT * 1000,
-			filter: i => i.user.id === interaction.user.id && i.message.id === replyId
+			filter: i => i.message.id === replyId
 		});
 
 		const countdown = setInterval(() => this.countdown(interaction, --timeout, confirmBtns, baseText), 1000);
 
 		collector.on('collect', async (i: ButtonInteraction) => {
 			if (interaction.user.id !== i.user.id) {
-				await interaction.reply({
+				await i.reply({
 					content: 'You cannot respond to a command you did not execute',
 					ephemeral: true
 				});

--- a/src/commands/admin/setassign.ts
+++ b/src/commands/admin/setassign.ts
@@ -26,6 +26,9 @@ export default class extends Command {
 		const newRole: AssignableRole = { id: role.id };
 
 		if (await assignables.countDocuments(newRole) > 0) {
+			if (!await modifyRoleDD(interaction, role, false, 'REMOVE')) {
+				return interaction.reply('Unable to remove role from dropdown menu,');
+			}
 			assignables.findOneAndDelete(newRole);
 			return interaction.reply(`The role \`${role.name}\` has been removed.`);
 		} else {

--- a/src/commands/fun/rockpaperscissors.ts
+++ b/src/commands/fun/rockpaperscissors.ts
@@ -31,16 +31,15 @@ export default class extends Command {
 		interaction.fetchReply().then(reply => { replyId = reply.id; });
 
 		const collector = interaction.channel.createMessageComponentCollector({
-			max: 1,
 			time: DECISION_TIMEOUT * 1000,
-			filter: i => i.user.id === interaction.user.id && i.message.id === replyId
+			filter: i => i.message.id === replyId
 		});
 
 		const countdown = setInterval(() => this.countdown(interaction, --timeout, confirmBtns, choiceEmbed), 1000);
 
 		collector.on('collect', async (i: ButtonInteraction) => {
 			if (interaction.user.id !== i.user.id) {
-				await interaction.reply({
+				await i.reply({
 					content: 'You cannot respond to a command you did not execute',
 					ephemeral: true
 				});

--- a/src/commands/fun/xkcd.ts
+++ b/src/commands/fun/xkcd.ts
@@ -66,7 +66,7 @@ export default class extends Command {
 		interaction.fetchReply().then(reply => { replyId = reply.id; });
 
 		const collector = interaction.channel.createMessageComponentCollector({
-			filter: i => i.message.id === replyId
+			filter: i => i.message.id === replyId && i.user.id === interaction.user.id
 		});
 
 		collector.on('collect', async (i: ButtonInteraction) => {

--- a/src/commands/fun/xkcd.ts
+++ b/src/commands/fun/xkcd.ts
@@ -66,10 +66,17 @@ export default class extends Command {
 		interaction.fetchReply().then(reply => { replyId = reply.id; });
 
 		const collector = interaction.channel.createMessageComponentCollector({
-			filter: i => i.message.id === replyId && i.user.id === interaction.user.id
+			filter: i => i.message.id === replyId
 		});
 
 		collector.on('collect', async (i: ButtonInteraction) => {
+			if (interaction.user.id !== i.user.id) {
+				await i.reply({
+					content: 'You cannot respond to a command you did not execute',
+					ephemeral: true
+				});
+				return;
+			}
 			i.deferUpdate();
 			if (i.customId === 'previous') {
 				if (comicNum - 1 > 0) {

--- a/src/commands/info/leaderboard.ts
+++ b/src/commands/info/leaderboard.ts
@@ -102,7 +102,7 @@ export default class extends Command {
 			.setDescription(content)
 			.setImage('attachment://leaderboard.png');
 
-		interaction.editReply({
+		interaction.followUp({
 			embeds: [embed],
 			files: [{ name: 'leaderboard.png', attachment: canvas.toBuffer() }]
 		});

--- a/src/commands/partial visibility question/archive.ts
+++ b/src/commands/partial visibility question/archive.ts
@@ -11,7 +11,7 @@ export default class extends Command {
 		if (!interaction.channel.isThread()) {
 			return interaction.reply({ embeds: [generateErrorEmbed('You must run this command in a private question thread.')], ephemeral: true });
 		}
-		interaction.reply(`Archiving thread...`);
+		await interaction.reply(`Archiving thread...`);
 		await interaction.channel.setArchived(true, `${interaction.user.username} archived the question.`);
 		interaction.editReply(`Thread archived.`);
 	}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -116,6 +116,7 @@ function addRole(interaction: CommandInteraction,
 		});
 		menu.addOptions([option]);
 		menu.setMaxValues(menu.options.length);
+		menu.options.sort((x, y) => x.label > y.label ? 1 : -1);
 	} else {
 		dropdownRow.addComponents(
 			new MessageSelectMenu()
@@ -150,6 +151,7 @@ function removeRole(interaction: CommandInteraction,
 
 		menu.spliceOptions(index, 1);
 		menu.setMaxValues(menu.options.length);
+		menu.options.sort((x, y) => x.label > y.label ? 1 : -1);
 		rolesMsg.edit({ components: menu.options.length > 0 ? [dropdownRow] : [] });
 		cont = false;
 	});


### PR DESCRIPTION
- archive doesn't fail to send the interaction and crash the bot now
- dropdown menu options get sorted if an item is added or removed
- xkcd button interactions are filtered to only the author
- removing an assignable role also removes it from the dropdown menu
- (NEW 2/5) /announcement now supports newlines, users can add in `\n` to the content parameter and it will automatically add a linebreak in that position
- (NEW 2/5) xkcd/rockpaperscissors give an ephemeral error response to non-author users who press the buttons