### PR TITLE
feat: add define command

### DIFF
--- a/src/commands/fun/define.ts
+++ b/src/commands/fun/define.ts
@@ -1,0 +1,27 @@
+import { ApplicationCommandOptionData, CommandInteraction } from 'discord.js';
+import { Command } from '@lib/types/Command';
+
+export default class extends Command {
+
+	description = 'Find the definition of a word.';
+	options: ApplicationCommandOptionData[] = [
+		{
+			name: 'word',
+			description: 'The word to define',
+			type: 'STRING',
+			required: true
+		}
+	]
+
+	run(interaction: CommandInteraction): Promise<void> {
+		const input = interaction.options.getString('word');
+
+		// Get the first word in the sentence and make it URL-friendly
+		if (input.indexOf(' ') !== -1) {
+			return interaction.reply({ content: 'You can only define one word at a time!', ephemeral: true });
+		}
+		const word = encodeURIComponent(input.toLowerCase());
+		return interaction.reply(`https://www.merriam-webster.com/dictionary/${word}`);
+	}
+
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26600014/156581973-5e665405-19b3-4b6e-bef0-29086e4bd5e9.png)
Taking this literally ;)

I spent about an hour trying to get it to check if the URL is valid, but it seems the only way to reliably do that is to add a dependency, so I didn't do that.

Takes a string input and returns a link to Merriam-Webster, which will have an autogenerated embed if it is a valid URL.